### PR TITLE
Document usage with tmux session level KUBECONFIG env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,11 @@ or with a custom template:
 set -g status-right "#[fg=black] #(kube-tmux '<{{.Context}}::{{.Namespace}}>') #H %H:%M %d.%m.%Y"
 ```
 
+If you are using [kube-tmuxp](https://github.com/arunvelsriram/kube-tmuxp) to work with multiple clusters then `KUBECONFIG` environment variable will be set at tmux session level. In this case use:
+```
+set -g status-right '#[fg=black] #(echo "$(tmux show-environment KUBECONFIG) kube-tmux" | sh)'
+```
+
 Consider reducing the status-interval for more current information:
 ```
 set -g status-interval 5


### PR DESCRIPTION
When using [kube-tmuxp](https://github.com/arunvelsriram/kube-tmuxp), there will be one tmux session per K8s cluster. So, `KUBECONFIG` environment variable will be set at tmux session level. We need to pass the `KUBECONFIG` explicitly for the status line to update on switching between sessions.

In this PR I have documented the above use case.